### PR TITLE
Fix getUserProfile return type

### DIFF
--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,13 +1,14 @@
-import { PrismaClient, User, Notification } from "@prisma/client";
+import { PrismaClient, User } from "@prisma/client";
 import {
   getPaginationParams,
   createPaginationResult,
 } from "../utils/pagination";
+import type { UserProfile } from "../types/user";
 
 export class UserService {
   constructor(private prisma: PrismaClient) {}
 
-  async getUserProfile(userId: string): Promise<User | null> {
+  async getUserProfile(userId: string): Promise<UserProfile | null> {
     return this.prisma.user.findUnique({
       where: { id: userId },
       select: {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -33,3 +33,22 @@ export interface BrokerIntegrationDTO {
   syncSchedule: string;
   fieldMappings?: Record<string, any>;
 }
+
+// Shape returned from the user profile query
+import type { User } from "@prisma/client";
+
+export type UserProfile = Pick<
+  User,
+  | "id"
+  | "email"
+  | "firstName"
+  | "lastName"
+  | "phone"
+  | "role"
+  | "profileImage"
+  | "stripeCustomerId"
+  | "stripeAccountId"
+  | "isEmailVerified"
+  | "lastLoginAt"
+  | "createdAt"
+>;


### PR DESCRIPTION
## Summary
- add `UserProfile` type for user details
- use the new type in `getUserProfile`

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'jest' and 'node')*
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_b_685c391b9b64832cbf2ceab26ba9ad37