### PR TITLE
Add user endpoints

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,0 +1,104 @@
+import { Request, Response } from "express";
+import { UserService } from "../services/userService";
+import { prisma } from "../utils/prisma";
+import { updateProfileSchema, updateRoleSchema } from "../utils/validations";
+import { AuthenticatedRequest } from "../middlewares/auth";
+import { logger } from "../utils/logger";
+
+const userService = new UserService(prisma);
+
+export const getProfile = async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const profile = await userService.getUserProfile(req.user!.id);
+    res.json(profile);
+  } catch (error: any) {
+    logger.error("Get profile error:", error);
+    res.status(400).json({ error: error.message });
+  }
+};
+
+export const updateProfile = async (
+  req: AuthenticatedRequest,
+  res: Response
+) => {
+  try {
+    const data = updateProfileSchema.parse(req.body);
+    const profile = await userService.updateUserProfile(req.user!.id, data);
+    res.json(profile);
+  } catch (error: any) {
+    logger.error("Update profile error:", error);
+    if (error.name === "ZodError") {
+      return res.status(400).json({ error: "Validation failed", details: error.errors });
+    }
+    res.status(400).json({ error: error.message });
+  }
+};
+
+export const updateRole = async (
+  req: AuthenticatedRequest,
+  res: Response
+) => {
+  try {
+    const { userId, role } = updateRoleSchema.parse({ ...req.body, userId: req.params.id });
+    const user = await userService.updateUserRole(userId, role);
+    res.json(user);
+  } catch (error: any) {
+    logger.error("Update role error:", error);
+    if (error.name === "ZodError") {
+      return res.status(400).json({ error: "Validation failed", details: error.errors });
+    }
+    res.status(400).json({ error: error.message });
+  }
+};
+
+export const getNotifications = async (
+  req: AuthenticatedRequest,
+  res: Response
+) => {
+  try {
+    const notifications = await userService.getNotifications(req.user!.id, req.query);
+    res.json(notifications);
+  } catch (error: any) {
+    logger.error("Get notifications error:", error);
+    res.status(400).json({ error: error.message });
+  }
+};
+
+export const markNotificationAsRead = async (
+  req: AuthenticatedRequest,
+  res: Response
+) => {
+  try {
+    await userService.markNotificationAsRead(req.user!.id, req.params.id);
+    res.json({ message: "Notification marked as read" });
+  } catch (error: any) {
+    logger.error("Mark notification read error:", error);
+    res.status(400).json({ error: error.message });
+  }
+};
+
+export const markAllNotificationsAsRead = async (
+  req: AuthenticatedRequest,
+  res: Response
+) => {
+  try {
+    await userService.markAllNotificationsAsRead(req.user!.id);
+    res.json({ message: "All notifications marked as read" });
+  } catch (error: any) {
+    logger.error("Mark all notifications read error:", error);
+    res.status(400).json({ error: error.message });
+  }
+};
+
+export const deleteAccount = async (
+  req: AuthenticatedRequest,
+  res: Response
+) => {
+  try {
+    await userService.deleteUserAccount(req.user!.id);
+    res.json({ message: "Account deleted" });
+  } catch (error: any) {
+    logger.error("Delete account error:", error);
+    res.status(400).json({ error: error.message });
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { config } from "./config/config";
 import { logger } from "./utils/logger";
 import { errorHandler } from "./middlewares/errorHandler";
 import { authRoutes } from "./routes/auth";
+import { userRoutes } from "./routes/user";
 import { setupSwagger } from "./config/swagger";
 
 const app = express();
@@ -42,6 +43,7 @@ app.get("/health", (req, res) => {
 
 //Routes
 app.use("/api/auth", authRoutes);
+app.use("/api/users", userRoutes);
 
 //Error handling
 app.use(errorHandler);

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -1,0 +1,141 @@
+import { Router } from "express";
+import {
+  getProfile,
+  updateProfile,
+  updateRole,
+  getNotifications,
+  markNotificationAsRead,
+  markAllNotificationsAsRead,
+  deleteAccount,
+} from "../controllers/userController";
+import { authenticate, authorize } from "../middlewares/auth";
+
+const router = Router();
+
+/**
+ * @swagger
+ * /api/users/profile:
+ *   get:
+ *     summary: Get current user profile
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: User profile
+ */
+router.get("/profile", authenticate, getProfile);
+
+/**
+ * @swagger
+ * /api/users/profile:
+ *   put:
+ *     summary: Update current user profile
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *     responses:
+ *       200:
+ *         description: Profile updated
+ */
+router.put("/profile", authenticate, updateProfile);
+
+/**
+ * @swagger
+ * /api/users/{id}/role:
+ *   put:
+ *     summary: Update user role
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               role:
+ *                 type: string
+ *                 enum: [BUYER, SELLER, BROKER, ADMIN]
+ *     responses:
+ *       200:
+ *         description: Role updated
+ */
+router.put("/:id/role", authenticate, authorize("ADMIN"), updateRole);
+
+/**
+ * @swagger
+ * /api/users/notifications:
+ *   get:
+ *     summary: Get user notifications
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Notification list
+ */
+router.get("/notifications", authenticate, getNotifications);
+
+/**
+ * @swagger
+ * /api/users/notifications/{id}/read:
+ *   patch:
+ *     summary: Mark notification as read
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Notification marked as read
+ */
+router.patch("/notifications/:id/read", authenticate, markNotificationAsRead);
+
+/**
+ * @swagger
+ * /api/users/notifications/read-all:
+ *   patch:
+ *     summary: Mark all notifications as read
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: All notifications marked as read
+ */
+router.patch("/notifications/read-all", authenticate, markAllNotificationsAsRead);
+
+/**
+ * @swagger
+ * /api/users/account:
+ *   delete:
+ *     summary: Delete user account
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Account deleted
+ */
+router.delete("/account", authenticate, deleteAccount);
+
+export { router as userRoutes };

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -26,3 +26,15 @@ export const resetPasswordSchema = z.object({
 export const verifyEmailSchema = z.object({
   token: z.string().min(1, "Token is required"),
 });
+
+export const updateProfileSchema = z.object({
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+  phone: z.string().optional(),
+  profileImage: z.string().optional(),
+});
+
+export const updateRoleSchema = z.object({
+  userId: z.string(),
+  role: z.enum(["BUYER", "SELLER", "BROKER", "ADMIN"]),
+});


### PR DESCRIPTION
## Summary
- create user controller and routes
- add validation schemas for profile and role updates
- wire user routes into the Express app

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_685c329656cc832c960449ac88f1a256