### PR TITLE
Fix Express types import in utils auth

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,4 +1,4 @@
-import { Request } from "express";
+import { Request, Response, NextFunction } from "express";
 import { User } from "@prisma/client";
 import { errorResponse } from "./response";
 


### PR DESCRIPTION
## Summary
- fix missing Response and NextFunction imports in utils/auth.ts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c4be7351c832c8ca4c19c00847211