### PR TITLE
Add buyer offer management module

### DIFF
--- a/src/controllers/buyerController.ts
+++ b/src/controllers/buyerController.ts
@@ -1,0 +1,66 @@
+import { Response } from "express";
+import { AuthenticatedRequest } from "../middlewares/auth";
+import { BuyerService } from "../services/buyerService";
+import { prisma } from "../utils/prisma";
+import { createOfferSchema, updateOfferSchema } from "../utils/validations";
+import { logger } from "../utils/logger";
+
+const buyerService = new BuyerService(prisma);
+
+export const createOffer = async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const data = createOfferSchema.parse(req.body);
+    const offer = await buyerService.createOffer(req.user!.id, data);
+    res.status(201).json(offer);
+  } catch (error: any) {
+    logger.error("Create offer error:", error);
+    if (error.name === "ZodError") {
+      return res.status(400).json({ error: "Validation failed", details: error.errors });
+    }
+    res.status(400).json({ error: error.message });
+  }
+};
+
+export const listOffers = async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const offers = await buyerService.listOffers(req.user!.id, req.query);
+    res.json(offers);
+  } catch (error: any) {
+    logger.error("List offers error:", error);
+    res.status(400).json({ error: error.message });
+  }
+};
+
+export const getOffer = async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const offer = await buyerService.getOfferById(req.user!.id, req.params.id);
+    res.json(offer);
+  } catch (error: any) {
+    logger.error("Get offer error:", error);
+    res.status(404).json({ error: error.message });
+  }
+};
+
+export const updateOffer = async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const data = updateOfferSchema.parse(req.body);
+    const offer = await buyerService.updateOffer(req.user!.id, req.params.id, data);
+    res.json(offer);
+  } catch (error: any) {
+    logger.error("Update offer error:", error);
+    if (error.name === "ZodError") {
+      return res.status(400).json({ error: "Validation failed", details: error.errors });
+    }
+    res.status(400).json({ error: error.message });
+  }
+};
+
+export const cancelOffer = async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const offer = await buyerService.cancelOffer(req.user!.id, req.params.id);
+    res.json(offer);
+  } catch (error: any) {
+    logger.error("Cancel offer error:", error);
+    res.status(400).json({ error: error.message });
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { logger } from "./utils/logger";
 import { errorHandler } from "./middlewares/errorHandler";
 import { authRoutes } from "./routes/auth";
 import { userRoutes } from "./routes/user";
+import { buyerRoutes } from "./routes/buyer";
 import { setupSwagger } from "./config/swagger";
 
 const app = express();
@@ -44,6 +45,7 @@ app.get("/health", (req, res) => {
 //Routes
 app.use("/api/auth", authRoutes);
 app.use("/api/users", userRoutes);
+app.use("/api/buyers", buyerRoutes);
 
 //Error handling
 app.use(errorHandler);

--- a/src/routes/buyer.ts
+++ b/src/routes/buyer.ts
@@ -1,0 +1,19 @@
+import { Router } from "express";
+import {
+  createOffer,
+  listOffers,
+  getOffer,
+  updateOffer,
+  cancelOffer,
+} from "../controllers/buyerController";
+import { authenticate, authorize } from "../middlewares/auth";
+
+const router = Router();
+
+router.post("/offers", authenticate, authorize("BUYER"), createOffer);
+router.get("/offers", authenticate, authorize("BUYER"), listOffers);
+router.get("/offers/:id", authenticate, authorize("BUYER"), getOffer);
+router.put("/offers/:id", authenticate, authorize("BUYER"), updateOffer);
+router.delete("/offers/:id", authenticate, authorize("BUYER"), cancelOffer);
+
+export { router as buyerRoutes };

--- a/src/services/buyerService.ts
+++ b/src/services/buyerService.ts
@@ -1,0 +1,139 @@
+import { PrismaClient } from "@prisma/client";
+import { CreateOfferDTO, UpdateOfferDTO, OfferResponse } from "../types/buyer";
+import { getPaginationParams, createPaginationResult } from "../utils/pagination";
+import type { PaginationResult } from "../types/api";
+
+export class BuyerService {
+  constructor(private prisma: PrismaClient) {}
+
+  async createOffer(buyerId: string, data: CreateOfferDTO): Promise<OfferResponse> {
+    const offer = await this.prisma.$transaction(async (tx) => {
+      const created = await tx.offer.create({
+        data: {
+          buyerId,
+          eventId: data.eventId,
+          maxPrice: data.maxPrice,
+          quantity: data.quantity,
+          message: data.message,
+          expiresAt: data.expiresAt,
+        },
+      });
+
+      if (data.sectionIds && data.sectionIds.length) {
+        const sections = data.sectionIds.map((sectionId) => ({
+          offerId: created.id,
+          sectionId,
+        }));
+        await tx.offerSection.createMany({ data: sections });
+      }
+
+      return created;
+    });
+
+    const sections = await this.prisma.offerSection.findMany({
+      where: { offerId: offer.id },
+      select: { sectionId: true },
+    });
+
+    return {
+      ...offer,
+      sectionIds: sections.map((s) => s.sectionId),
+    };
+  }
+
+  async listOffers(
+    buyerId: string,
+    query: any
+  ): Promise<PaginationResult<OfferResponse>> {
+    const { page, limit, skip } = getPaginationParams(query);
+
+    const [offers, total] = await Promise.all([
+      this.prisma.offer.findMany({
+        where: { buyerId },
+        include: { sections: { select: { sectionId: true } } },
+        orderBy: { createdAt: "desc" },
+        skip,
+        take: limit,
+      }),
+      this.prisma.offer.count({ where: { buyerId } }),
+    ]);
+
+    const mapped = offers.map((offer) => ({
+      ...offer,
+      sectionIds: offer.sections.map((s) => s.sectionId),
+    }));
+
+    return createPaginationResult(mapped, total, page, limit);
+  }
+
+  async getOfferById(buyerId: string, offerId: string): Promise<OfferResponse> {
+    const offer = await this.prisma.offer.findFirst({
+      where: { id: offerId, buyerId },
+      include: { sections: { select: { sectionId: true } } },
+    });
+
+    if (!offer) {
+      throw new Error("Offer not found");
+    }
+
+    return {
+      ...offer,
+      sectionIds: offer.sections.map((s) => s.sectionId),
+    };
+  }
+
+  async updateOffer(
+    buyerId: string,
+    offerId: string,
+    data: UpdateOfferDTO
+  ): Promise<OfferResponse> {
+    const offer = await this.prisma.$transaction(async (tx) => {
+      const updated = await tx.offer.update({
+        where: { id: offerId, buyerId },
+        data: {
+          maxPrice: data.maxPrice,
+          quantity: data.quantity,
+          message: data.message,
+          expiresAt: data.expiresAt,
+          updatedAt: new Date(),
+        },
+      });
+
+      if (data.sectionIds) {
+        await tx.offerSection.deleteMany({ where: { offerId } });
+        const sections = data.sectionIds.map((sectionId) => ({
+          offerId,
+          sectionId,
+        }));
+        if (sections.length) {
+          await tx.offerSection.createMany({ data: sections });
+        }
+      }
+
+      return updated;
+    });
+
+    const sections = await this.prisma.offerSection.findMany({
+      where: { offerId: offer.id },
+      select: { sectionId: true },
+    });
+
+    return {
+      ...offer,
+      sectionIds: sections.map((s) => s.sectionId),
+    };
+  }
+
+  async cancelOffer(buyerId: string, offerId: string): Promise<OfferResponse> {
+    const offer = await this.prisma.offer.update({
+      where: { id: offerId, buyerId },
+      data: { status: "CANCELLED" },
+      include: { sections: { select: { sectionId: true } } },
+    });
+
+    return {
+      ...offer,
+      sectionIds: offer.sections.map((s) => s.sectionId),
+    };
+  }
+}

--- a/src/types/buyer.ts
+++ b/src/types/buyer.ts
@@ -1,0 +1,30 @@
+export interface CreateOfferDTO {
+  eventId: string;
+  maxPrice: number;
+  quantity: number;
+  sectionIds: string[];
+  message?: string;
+  expiresAt: Date;
+}
+
+export interface UpdateOfferDTO {
+  maxPrice?: number;
+  quantity?: number;
+  sectionIds?: string[];
+  message?: string;
+  expiresAt?: Date;
+}
+
+export interface OfferResponse {
+  id: string;
+  eventId: string;
+  buyerId: string;
+  maxPrice: number;
+  quantity: number;
+  message?: string | null;
+  status: string;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+  sectionIds: string[];
+}

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -38,3 +38,14 @@ export const updateRoleSchema = z.object({
   userId: z.string(),
   role: z.enum(["BUYER", "SELLER", "BROKER", "ADMIN"]),
 });
+
+export const createOfferSchema = z.object({
+  eventId: z.string(),
+  maxPrice: z.number().positive(),
+  quantity: z.number().int().positive(),
+  sectionIds: z.array(z.string()).nonempty(),
+  message: z.string().optional(),
+  expiresAt: z.coerce.date(),
+});
+
+export const updateOfferSchema = createOfferSchema.partial();


### PR DESCRIPTION
## Summary
- add DTOs for buyer offers
- implement buyer service for offers CRUD
- add buyer controller and routes
- validate offer input with Zod
- expose buyer routes in main app

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_685c4e321310832c8568116fa7c747e2