### PR TITLE
Fix TransactionStatus typing

### DIFF
--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../utils/prisma";
+import { TransactionStatus } from "@prisma/client";
 import { TransactionSearchQuery } from "../types/transaction";
 import { PaginationResponse } from "../types/api";
 import { logger } from "../utils/logger";
@@ -169,7 +170,7 @@ export class TransactionService {
 
   async updateTransactionStatus(
     transactionId: string,
-    status: string,
+    status: TransactionStatus,
     notes?: string
   ) {
     const transaction = await prisma.transaction.update({

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -1,0 +1,11 @@
+import { PaginationQuery } from "./api";
+import { TransactionStatus } from "@prisma/client";
+
+export interface TransactionSearchQuery extends PaginationQuery {
+  buyerId?: string;
+  sellerId?: string;
+  eventId?: string;
+  status?: TransactionStatus;
+  dateFrom?: string;
+  dateTo?: string;
+}


### PR DESCRIPTION
## Summary
- import `TransactionStatus` from Prisma client
- type `status` parameter in TransactionService with `TransactionStatus`
- add missing `TransactionSearchQuery` type

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_b_6861751e5e80832c9d197c1f3c8fea3b